### PR TITLE
:sparkles:  Add support for multi tile objects

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -78,8 +78,23 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
   const handleMouseClick = (x: number, y: number, event: ThreeEvent<PointerEvent>) => {
     if (event.nativeEvent.button !== 0) return; // Ensure it is a left-click
     if (selectedZone.type && selectedZone.type !== 'conveyor') {
-      updateCells(x, y);
+      if (validatePlacement(x, y)) {
+        updateCells(x, y);
+      }
     }
+  };
+
+  const validatePlacement = (x: number, y: number) => {
+    // Check if the entire 2x2 area is valid and empty
+    for (let i = 0; i < 2; i++) {
+      for (let j = 0; j < 2; j++) {
+        const cell = cells.find(cell => cell.x === x + i * CELL_SIZE && cell.y === y + j * CELL_SIZE);
+        if (!cell || cell.building) {
+          return false;
+        }
+      }
+    }
+    return true;
   };
 
   const updateCells = (x: number, y: number) => {
@@ -195,6 +210,7 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
             hoveredCell.y + CELL_SIZE,
           ]}
           cellSize={CELL_SIZE}
+          valid={validatePlacement(hoveredCell.x, hoveredCell.y)}
         />
       )}
       {tempCells.map((cell) => (
@@ -223,4 +239,3 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
 };
 
 export { Grid };
-

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -11,6 +11,7 @@ import excavator2Texture from '../../textures/excavator.png';
 import excavator3Texture from '../../textures/excavator.png';
 import excavator1Texture from '../../textures/excavator.png';
 import { GridSprite } from '../CitySprite/GridSprite';
+import { GridOutline } from '../GridOutline/GridOutline';
 import './Grid.css';
 
 const GRID_SIZE = 200;
@@ -45,6 +46,7 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
   const [tempCells, setTempCells] = useState(cells);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState<{ x: number, y: number } | null>(null);
+  const [hoveredCell, setHoveredCell] = useState<{ x: number, y: number } | null>(null);
 
   const handleMouseDown = (x: number, y: number, event: ThreeEvent<PointerEvent>) => {
     if (event.nativeEvent.button !== 0) return; // Ensure it is a left-click
@@ -60,6 +62,7 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
     if (isDragging && selectedZone.type === 'conveyor') {
       updateTempCells(x, y);
     }
+    setHoveredCell({ x, y });
   };
 
   const handleMouseUp = (event: ThreeEvent<PointerEvent>) => {
@@ -69,6 +72,7 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
     }
     setIsDragging(false);
     setDragStart(null);
+    setHoveredCell(null); // Reset the hovered cell on mouse up
   };
 
   const handleMouseClick = (x: number, y: number, event: ThreeEvent<PointerEvent>) => {
@@ -183,6 +187,16 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
 
   return (
     <>
+      {hoveredCell && selectedZone.type !== 'conveyor' && selectedZone.type && (
+        <GridOutline
+          position={[
+            hoveredCell.x + CELL_SIZE,
+            0,
+            hoveredCell.y + CELL_SIZE,
+          ]}
+          cellSize={CELL_SIZE}
+        />
+      )}
       {tempCells.map((cell) => (
         <React.Fragment key={`${cell.x}-${cell.y}`}>
           <GridSquare
@@ -209,3 +223,4 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
 };
 
 export { Grid };
+

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -42,32 +42,60 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
     return initialCells;
   });
 
+  const [tempCells, setTempCells] = useState(cells);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState<{ x: number, y: number } | null>(null);
-  const [tempCells, setTempCells] = useState(cells);
-  const [draggedCells, setDraggedCells] = useState<{ x: number, y: number }[]>([]);
 
   const handleMouseDown = (x: number, y: number, event: ThreeEvent<PointerEvent>) => {
     if (event.nativeEvent.button !== 0) return; // Ensure it is a left-click
-    setIsDragging(true);
-    setDragStart({ x, y });
-    setDraggedCells([]);
+    if (selectedZone.type === 'conveyor') {
+      setIsDragging(true);
+      setDragStart({ x, y });
+    } else {
+      handleMouseClick(x, y, event);
+    }
   };
 
   const handleMouseEnter = (x: number, y: number) => {
-    if (isDragging && selectedZone.type) {
+    if (isDragging && selectedZone.type === 'conveyor') {
       updateTempCells(x, y);
     }
   };
 
   const handleMouseUp = (event: ThreeEvent<PointerEvent>) => {
     if (event.nativeEvent.button !== 0) return; // Ensure it is a left-click
-    if (isDragging && selectedZone.type) {
+    if (isDragging && selectedZone.type === 'conveyor') {
       setCells(tempCells);
     }
     setIsDragging(false);
     setDragStart(null);
-    setDraggedCells([]);
+  };
+
+  const handleMouseClick = (x: number, y: number, event: ThreeEvent<PointerEvent>) => {
+    if (event.nativeEvent.button !== 0) return; // Ensure it is a left-click
+    if (selectedZone.type && selectedZone.type !== 'conveyor') {
+      updateCells(x, y);
+    }
+  };
+
+  const updateCells = (x: number, y: number) => {
+    const newCells = cells.map(cell => {
+      if (selectedZone.type !== 'conveyor') {
+        const within2x2 = (cell.x >= x && cell.x < x + 2 * CELL_SIZE) && (cell.y >= y && cell.y < y + 2 * CELL_SIZE);
+        if (within2x2) {
+          return {
+            ...cell,
+            type: selectedZone.type,
+            density: selectedZone.density,
+            building: selectedZone.type,
+          };
+        }
+      }
+      return cell;
+    });
+
+    setCells(newCells);
+    setTempCells(newCells); // Ensure tempCells are updated to reflect the placed item
   };
 
   const updateTempCells = (x: number, y: number) => {
@@ -78,15 +106,12 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
     const yMin = Math.min(dragStart.y, y);
     const yMax = Math.max(dragStart.y, y);
 
-    const newDraggedCells: { x: number, y: number }[] = [];
-
     const newTempCells = cells.map(cell => {
       if (selectedZone.type === 'conveyor') {
         // Allow conveyors only in straight lines
         if (dragStart.x === x) {
           // Vertical line
           if (cell.x === dragStart.x && cell.y >= yMin && cell.y <= yMax) {
-            newDraggedCells.push({ x: cell.x, y: cell.y });
             return {
               ...cell,
               type: selectedZone.type,
@@ -97,7 +122,6 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
         } else if (dragStart.y === y) {
           // Horizontal line
           if (cell.y === dragStart.y && cell.x >= xMin && cell.x <= xMax) {
-            newDraggedCells.push({ x: cell.x, y: cell.y });
             return {
               ...cell,
               type: selectedZone.type,
@@ -106,20 +130,11 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
             };
           }
         }
-      } else if (cell.x >= xMin && cell.x <= xMax && cell.y >= yMin && cell.y <= yMax) {
-        newDraggedCells.push({ x: cell.x, y: cell.y });
-        return {
-          ...cell,
-          type: selectedZone.type,
-          density: selectedZone.density,
-          building: selectedZone.type,
-        };
       }
       return cell;
     });
 
     setTempCells(newTempCells);
-    setDraggedCells(newDraggedCells);
   };
 
   const getColor = (cell, currentSelected) => {
@@ -166,10 +181,6 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
     }
   };
 
-  const isDraggedCell = (x: number, y: number) => {
-    return draggedCells.some(cell => cell.x === x && cell.y === y);
-  };
-
   return (
     <>
       {tempCells.map((cell) => (
@@ -182,7 +193,7 @@ const Grid: React.FC<GridProps> = ({ selectedZone, currentSelected, map }) => {
             color={getColor(cell, currentSelected)}
             cellSize={CELL_SIZE} // Pass CELL_SIZE as a prop
           />
-          {(!isDraggedCell(cell.x, cell.y)) && cell.building && (
+          {cell.building && (
             <GridSprite
               imageUrl={getBuildingTexture(cell.building)}
               position={[cell.x + CELL_SIZE / 2, 1, cell.y + CELL_SIZE / 2]}

--- a/src/components/GridOutline/GridOutline.tsx
+++ b/src/components/GridOutline/GridOutline.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 interface GridOutlineProps {
   position: [number, number, number];
   cellSize: number;
+  valid: boolean;
 }
 
-const GridOutline: React.FC<GridOutlineProps> = ({ position, cellSize }) => {
+const GridOutline: React.FC<GridOutlineProps> = ({ position, cellSize, valid }) => {
   return (
     <mesh position={position}>
       <boxGeometry args={[2 * cellSize, 0.2, 2 * cellSize]} />
-      <meshBasicMaterial color="red" wireframe />
+      <meshBasicMaterial color={valid ? 'green' : 'red'} wireframe />
     </mesh>
   );
 };

--- a/src/components/GridOutline/GridOutline.tsx
+++ b/src/components/GridOutline/GridOutline.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface GridOutlineProps {
+  position: [number, number, number];
+  cellSize: number;
+}
+
+const GridOutline: React.FC<GridOutlineProps> = ({ position, cellSize }) => {
+  return (
+    <mesh position={position}>
+      <boxGeometry args={[2 * cellSize, 0.2, 2 * cellSize]} />
+      <meshBasicMaterial color="red" wireframe />
+    </mesh>
+  );
+};
+
+export { GridOutline };


### PR DESCRIPTION
```diff
+ Add non Conveyor objects to take a 2x2 grid on placement
+ Add placement valid/invalid indicators to prevent placing 2x2 over a area where it should be allowed
```